### PR TITLE
Ensure default_leading is same in shallow copy

### DIFF
--- a/lib/prawn/grouping.rb
+++ b/lib/prawn/grouping.rb
@@ -58,6 +58,7 @@ module Prawn
         pdf.font_families.update font_families
         pdf.font font.name
         pdf.font_size font_size
+        pdf.default_leading = default_leading
       end
     end
   end


### PR DESCRIPTION
Noticed that `group` wasn't working correctly if `default_leading` isn't zero.
