### PR TITLE
yield instead of instance_exec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.3
+  - 2.2.3
   - rbx-2
-  - jruby-19mode
+  - jruby-head
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/lib/prawn/grouping.rb
+++ b/lib/prawn/grouping.rb
@@ -16,7 +16,7 @@ module Prawn
     #     <tt>:fits_current_context</tt>:: A proc called before the content is
     #                                      rendered and does fit context.
     #
-    def group(options = {}, &b)
+    def group(options = {})
       too_tall             = options[:too_tall]
       fits_new_context     = options[:fits_new_context]
       fits_current_context = options[:fits_current_context]
@@ -24,27 +24,27 @@ module Prawn
       # create a temporary document with current context and offset
       pdf = create_box_clone
       pdf.y = y
-      pdf.instance_exec pdf, &b
+      yield pdf
 
       if pdf.page_count > 1
         # create a temporary document without offset
         pdf = create_box_clone
-        pdf.instance_exec pdf, &b
+        yield pdf
 
         if pdf.page_count > 1
           # does not fit new context
           too_tall.call if too_tall
-          b.call(self)
+          yield self
         else
           fits_new_context.call if fits_new_context
           bounds.move_past_bottom
-          b.call(self)
+          yield self
         end
         return false
       else
         # just render it
         fits_current_context.call if fits_current_context
-        b.call(self)
+        yield self
         return true
       end
     end


### PR DESCRIPTION
Allows the block to be run in the context it was defined. Block parameter is now mandatory.

Simple example in Rails view:

```ruby
# I want to group this:
pdf.text t('some.translation')
pdf.text 'some other text'

# --> I can simply wrap it around now
pdf.group.do |g|
   g.text t('some.translation')
   g.text 'some other text'
end
```

Without this PR, `t` is not defined because it does not exist in the changed context. It had to be done like this:

```ruby
translation = t('some.translation')
group.do |g|
   g.text translation
   g.text 'some other text'
end
```

This can get really messy if you want to group more complex things.

With this PR, the context is not changed anymore.

Only downside: The block parameter is mandatory, not only in `jruby`. But IMO the context should not be changed because it complicates things more than it solves (only benefit: the optional block parameter).