### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }} ${{ matrix.gemfile }}
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.0'
+          - 2.7
+          - 2.6
+        gemfile:
+          - gemfiles/prawn_2_4.gemfile
+          - gemfiles/prawn_2_3.gemfile
+          - gemfiles/prawn_2_2.gemfile
+          - gemfiles/prawn_2_1.gemfile
+        exclude:
+          - ruby: '3.0'
+            gemfile: gemfiles/prawn_2_3.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/prawn_2_2.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/prawn_2_1.gemfile
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Test
+        run: bundle exec rake spec

--- a/gemfiles/prawn_2_3.gemfile
+++ b/gemfiles/prawn_2_3.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../'
+
+gem "prawn", "~> 2.3.0"

--- a/gemfiles/prawn_2_4.gemfile
+++ b/gemfiles/prawn_2_4.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../'
+
+gem "prawn", "~> 2.4.0"


### PR DESCRIPTION
Migrate CI to GitHub actions, as Travis CI.org is no longer supported

This PR adds a basic GitHub actions file for CI.  A couple of items to note:

1. It adds Gemfiles for more recent versions of Prawn
2. It runs against Ruby 2.6-3.0.  Ruby 2.5 and earlier are EOLd.  Ruby 3.1 is not included because it requires that `prawn` include the `matrix` gem explicitly, which is not currently the case in any released versions.